### PR TITLE
fix custom function cannot use in returns() bug

### DIFF
--- a/core/src/main/java/org/apache/flink/streaming/siddhi/SiddhiStream.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/SiddhiStream.java
@@ -272,7 +272,7 @@ public abstract class SiddhiStream {
             siddhiContext.setExtensions(environment.getExtensions());
             siddhiContext.setExecutionConfig(environment.getExecutionEnvironment().getConfig());
             TypeInformation<T> typeInformation =
-                SiddhiTypeFactory.getTupleTypeInformation(siddhiContext.getAllEnrichedExecutionPlan(), outStreamId);
+                SiddhiTypeFactory.getTupleTypeInformation(siddhiContext.getAllEnrichedExecutionPlan(), outStreamId, siddhiContext);
             siddhiContext.setOutputStreamType(typeInformation);
             return returnsInternal(siddhiContext);
         }

--- a/core/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiTypeFactory.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiTypeFactory.java
@@ -22,16 +22,14 @@ import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.streaming.siddhi.operator.SiddhiOperatorContext;
 import org.wso2.siddhi.core.SiddhiAppRuntime;
 import org.wso2.siddhi.core.SiddhiManager;
 import org.wso2.siddhi.query.api.definition.AbstractDefinition;
 import org.wso2.siddhi.query.api.definition.Attribute;
 import org.wso2.siddhi.query.api.definition.StreamDefinition;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Siddhi Type Utils for conversion between Java Type, Siddhi Field Type, Stream Definition, and Flink Type Information.
@@ -84,6 +82,34 @@ public class SiddhiTypeFactory {
         }
     }
 
+    public static AbstractDefinition getStreamDefinition(String executionPlan, String streamId, SiddhiOperatorContext siddhiOperatorContext) {
+        SiddhiManager siddhiManager = null;
+        SiddhiAppRuntime runtime = null;
+        try {
+            siddhiManager = new SiddhiManager();
+            Map extensions = siddhiOperatorContext.getExtensions();
+            Iterator<Map.Entry<String,Class<?>>> iterator = extensions.entrySet().iterator();
+            while(iterator.hasNext()){
+                Map.Entry<String,Class<?>> entry = iterator.next();
+                siddhiManager.setExtension(entry.getKey(), entry.getValue());
+            }
+            runtime = siddhiManager.createSiddhiAppRuntime(executionPlan);
+            Map<String, StreamDefinition> definitionMap = runtime.getStreamDefinitionMap();
+            if (definitionMap.containsKey(streamId)) {
+                return definitionMap.get(streamId);
+            } else {
+                throw new IllegalArgumentException("Unknown stream id" + streamId);
+            }
+        } finally {
+            if (runtime != null) {
+                runtime.shutdown();
+            }
+            if (siddhiManager != null) {
+                siddhiManager.shutdown();
+            }
+        }
+    }
+
     public static <T extends Tuple> TypeInformation<T> getTupleTypeInformation(AbstractDefinition definition) {
         List<TypeInformation> types = new ArrayList<>();
         for (Attribute attribute : definition.getAttributeList()) {
@@ -98,6 +124,10 @@ public class SiddhiTypeFactory {
 
     public static <T extends Tuple> TypeInformation<T> getTupleTypeInformation(String executionPlan, String streamId) {
         return getTupleTypeInformation(getStreamDefinition(executionPlan, streamId));
+    }
+
+    public static <T extends Tuple> TypeInformation<T> getTupleTypeInformation(String executionPlan, String streamId, SiddhiOperatorContext siddhiOperatorContext) {
+        return getTupleTypeInformation(getStreamDefinition(executionPlan, streamId,siddhiOperatorContext));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
If I register a custom function like this:
cep.registerExtension("str:groupConcat", GroupConcatFunctionExtension.class);

Below code will return an exception like 'groupConcat() is neither a function or aggregate':
DataStream outstream2 = cep.from("inputstream2").cql("from inputstream2#window.timeBatch(1 sec) " + "select str:groupConcat(dip) as related_alerts " + "group by sip " + "insert into outstream2") .returns("outstream2");

But if I change returns() to returnAsMap(), then it will works very well:
DataStream outstream2 = cep.from("inputstream2").cql("from inputstream2#window.timeBatch(1 sec) " + "select str:groupConcat(dip) as related_alerts " + "group by sip " + "insert into outstream2") .returnAsMap("outstream2");