### PR TITLE
Inserting stream definitions just before the query to preserve app le…

### DIFF
--- a/core/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiExecutionPlanner.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiExecutionPlanner.java
@@ -60,8 +60,16 @@ public class SiddhiExecutionPlanner {
         for (Map.Entry<String, SiddhiStreamSchema<?>> entry : dataStreamSchemas.entrySet()) {
             sb.append(entry.getValue().getStreamDefinitionExpression(entry.getKey()));
         }
-        sb.append(executionPlan);
-        enrichedExecutionPlan = sb.toString();
+                
+        int queryStart = executionPlan.toLowerCase().indexOf("@query");
+        if (queryStart == -1) {
+        	queryStart = executionPlan.toLowerCase().indexOf("from ");
+        }
+        
+        String prefix = executionPlan.substring(0, queryStart);
+        String postfix = executionPlan.substring(queryStart);
+        
+        enrichedExecutionPlan = prefix + "\r\n" + sb.toString() + "\r\n" + postfix;
     }
 
     public static SiddhiExecutionPlanner of(Map<String, SiddhiStreamSchema<?>> dataStreamSchemas, String executionPlan) {


### PR DESCRIPTION
…vel annotations

Currently, the query is simply appended to stream definitions. If the query has annotations then the query becomes invalid. Hence the fix.