### PR TITLE
Adding support to preserve annotations at stream and app level.

### DIFF
--- a/core/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiExecutionPlanner.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiExecutionPlanner.java
@@ -60,8 +60,19 @@ public class SiddhiExecutionPlanner {
         for (Map.Entry<String, SiddhiStreamSchema<?>> entry : dataStreamSchemas.entrySet()) {
             sb.append(entry.getValue().getStreamDefinitionExpression(entry.getKey()));
         }
-        sb.append(executionPlan);
-        enrichedExecutionPlan = sb.toString();
+        
+        int queryStart = executionPlan.toLowerCase().indexOf("@query");
+        if (queryStart == -1) {
+        	queryStart = executionPlan.toLowerCase().indexOf("@info");
+        	if (queryStart == -1) {
+        		queryStart = executionPlan.toLowerCase().indexOf("from ");
+        	}	
+        }
+        
+        String prefix = executionPlan.substring(0, queryStart);
+        String postfix = executionPlan.substring(queryStart);
+        
+        enrichedExecutionPlan = prefix + "\r\n" + sb.toString() + "\r\n" + postfix;
     }
 
     public static SiddhiExecutionPlanner of(Map<String, SiddhiStreamSchema<?>> dataStreamSchemas, String executionPlan) {


### PR DESCRIPTION
Currently, the query is simply appended to stream definitions. If the query has annotations then the query becomes invalid. Hence the fix. If someone wants to enable statistics for a query, s/he has to add an app level annotation @app:statistics(reporter = 'console') before the query. However, this is currently not supported as the query is directly appended to the stream definitions misplacing the annotation and renders the query invalid. The fix is to insert the stream definitions just before the query. Below is the sample siddhi query with annotations which can be used for testing the fix.

@app:statistics(reporter = 'console') 
@query(name = 'echo')
from inputStream 
 select * 
 insert into outputStream