### PR TITLE
Partition query support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ language: java
 script: mvn clean test
 jdk:
   - oraclejdk8
+dist: trusty

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>flink-siddhi-parent_2.11</artifactId>
         <groupId>com.github.haoch</groupId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core/src/main/java/org/apache/flink/streaming/siddhi/SiddhiStream.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/SiddhiStream.java
@@ -41,8 +41,8 @@ import org.apache.flink.streaming.siddhi.utils.SiddhiTypeFactory;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
-import org.wso2.siddhi.query.api.definition.AbstractDefinition;
-import org.wso2.siddhi.query.api.definition.Attribute;
+import io.siddhi.query.api.definition.AbstractDefinition;
+import io.siddhi.query.api.definition.Attribute;
 
 import java.util.*;
 

--- a/core/src/main/java/org/apache/flink/streaming/siddhi/operator/AbstractSiddhiOperator.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/operator/AbstractSiddhiOperator.java
@@ -53,11 +53,11 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.siddhi.core.SiddhiAppRuntime;
-import org.wso2.siddhi.core.SiddhiManager;
-import org.wso2.siddhi.core.stream.input.InputHandler;
-import org.wso2.siddhi.query.api.definition.AbstractDefinition;
-import org.wso2.siddhi.query.api.definition.StreamDefinition;
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.query.api.definition.AbstractDefinition;
+import io.siddhi.query.api.definition.StreamDefinition;
 
 /**
  * <h1>Siddhi Runtime Operator</h1>
@@ -66,13 +66,13 @@ import org.wso2.siddhi.query.api.definition.StreamDefinition;
  *
  * <ul>
  * <li>
- * Create Siddhi {@link org.wso2.siddhi.core.SiddhiAppRuntime} according predefined execution plan and integrate with Flink Stream Operator lifecycle.
+ * Create Siddhi {@link io.siddhi.core.SiddhiAppRuntime} according predefined execution plan and integrate with Flink Stream Operator lifecycle.
  * </li>
  * <li>
  * Connect Flink DataStreams with predefined Siddhi Stream according to unique streamId
  * </li>
  * <li>
- * Convert native {@link StreamRecord} to Siddhi {@link org.wso2.siddhi.core.event.Event} according to {@link StreamSchema}, and send to Siddhi Runtime.
+ * Convert native {@link StreamRecord} to Siddhi {@link io.siddhi.core.event.Event} according to {@link StreamSchema}, and send to Siddhi Runtime.
  * </li>
  * <li>
  * Listen output callback event and convert as expected output type according to output {@link org.apache.flink.api.common.typeinfo.TypeInformation}, then output as typed DataStream.

--- a/core/src/main/java/org/apache/flink/streaming/siddhi/operator/SiddhiOperatorContext.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/operator/SiddhiOperatorContext.java
@@ -25,7 +25,7 @@ import org.apache.flink.streaming.siddhi.schema.StreamSchema;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.siddhi.utils.SiddhiExecutionPlanner;
 import org.apache.flink.util.Preconditions;
-import org.wso2.siddhi.core.SiddhiManager;
+import io.siddhi.core.SiddhiManager;
 
 import java.io.Serializable;
 import java.util.ArrayList;

--- a/core/src/main/java/org/apache/flink/streaming/siddhi/operator/StreamInMemOutputHandler.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/operator/StreamInMemOutputHandler.java
@@ -30,9 +30,9 @@ import org.apache.flink.streaming.siddhi.utils.SiddhiTupleFactory;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.siddhi.core.event.Event;
-import org.wso2.siddhi.core.stream.output.StreamCallback;
-import org.wso2.siddhi.query.api.definition.AbstractDefinition;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.stream.output.StreamCallback;
+import io.siddhi.query.api.definition.AbstractDefinition;
 
 /**
  * Siddhi Stream output callback handler and conver siddhi {@link Event} to required output type,
@@ -86,7 +86,7 @@ public class StreamInMemOutputHandler<R> extends StreamCallback {
         this.collectedRecords.clear();
     }
 
-    private Map<String, Object> toMap(Event event) {
+    public Map<String, Object> toMap(Event event) {
         Map<String, Object> map = new LinkedHashMap<>();
         for (int i = 0; i < definition.getAttributeNameArray().length; i++) {
             map.put(definition.getAttributeNameArray()[i], event.getData(i));

--- a/core/src/main/java/org/apache/flink/streaming/siddhi/operator/StreamOutputHandler.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/operator/StreamOutputHandler.java
@@ -33,9 +33,9 @@ import org.apache.flink.streaming.siddhi.utils.SiddhiTupleFactory;
 import org.apache.flink.types.Row;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.siddhi.core.event.Event;
-import org.wso2.siddhi.core.stream.output.StreamCallback;
-import org.wso2.siddhi.query.api.definition.AbstractDefinition;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.stream.output.StreamCallback;
+import io.siddhi.query.api.definition.AbstractDefinition;
 
 /**
  * Siddhi Stream output callback handler and conver siddhi {@link Event} to required output type,

--- a/core/src/main/java/org/apache/flink/streaming/siddhi/schema/SiddhiStreamSchema.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/schema/SiddhiStreamSchema.java
@@ -21,8 +21,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.siddhi.utils.SiddhiTypeFactory;
 import org.apache.flink.util.Preconditions;
-import org.wso2.siddhi.query.api.definition.Attribute;
-import org.wso2.siddhi.query.api.definition.StreamDefinition;
+import io.siddhi.query.api.definition.Attribute;
+import io.siddhi.query.api.definition.StreamDefinition;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiExecutionPlanner.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiExecutionPlanner.java
@@ -149,7 +149,7 @@ public class SiddhiExecutionPlanner {
             }
 
             // Output streams
-            OutputStream outputStream = ((Query) executionElement).getOutputStream();
+            OutputStream outputStream = query.getOutputStream();
             outputStreams.put(outputStream.getId(), selector.getSelectionList());
         }
 

--- a/core/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiTypeFactory.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/utils/SiddhiTypeFactory.java
@@ -24,11 +24,11 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.streaming.siddhi.router.StreamRoute;
 import org.apache.flink.streaming.siddhi.operator.SiddhiOperatorContext;
-import org.wso2.siddhi.core.SiddhiAppRuntime;
-import org.wso2.siddhi.core.SiddhiManager;
-import org.wso2.siddhi.query.api.definition.AbstractDefinition;
-import org.wso2.siddhi.query.api.definition.Attribute;
-import org.wso2.siddhi.query.api.definition.StreamDefinition;
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.query.api.definition.AbstractDefinition;
+import io.siddhi.query.api.definition.Attribute;
+import io.siddhi.query.api.definition.StreamDefinition;
 
 import java.util.*;
 

--- a/core/src/test/java/org/apache/flink/streaming/siddhi/extension/CustomPlusFunctionExtension.java
+++ b/core/src/test/java/org/apache/flink/streaming/siddhi/extension/CustomPlusFunctionExtension.java
@@ -17,15 +17,14 @@
 
 package org.apache.flink.streaming.siddhi.extension;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.wso2.siddhi.core.config.SiddhiAppContext;
-import org.wso2.siddhi.core.exception.SiddhiAppCreationException;
-import org.wso2.siddhi.core.executor.ExpressionExecutor;
-import org.wso2.siddhi.core.executor.function.FunctionExecutor;
-import org.wso2.siddhi.core.util.config.ConfigReader;
-import org.wso2.siddhi.query.api.definition.Attribute;
+import io.siddhi.core.config.SiddhiQueryContext;
+import io.siddhi.core.exception.SiddhiAppCreationException;
+import io.siddhi.core.executor.ExpressionExecutor;
+import io.siddhi.core.executor.function.FunctionExecutor;
+import io.siddhi.core.util.config.ConfigReader;
+import io.siddhi.core.util.snapshot.state.State;
+import io.siddhi.core.util.snapshot.state.StateFactory;
+import io.siddhi.query.api.definition.Attribute;
 
 public class CustomPlusFunctionExtension extends FunctionExecutor {
     private Attribute.Type returnType;
@@ -34,7 +33,7 @@ public class CustomPlusFunctionExtension extends FunctionExecutor {
      * The initialization method for FunctionExecutor, this method will be called before the other methods
      */
     @Override
-    protected void init(ExpressionExecutor[] expressionExecutors, ConfigReader configReader, SiddhiAppContext siddhiAppContext) {
+    protected StateFactory init(ExpressionExecutor[] expressionExecutors, ConfigReader configReader, SiddhiQueryContext siddhiQueryContext) {
         for (ExpressionExecutor expressionExecutor : attributeExpressionExecutors) {
             Attribute.Type attributeType = expressionExecutor.getReturnType();
             if (attributeType == Attribute.Type.DOUBLE) {
@@ -46,6 +45,7 @@ public class CustomPlusFunctionExtension extends FunctionExecutor {
                 returnType = Attribute.Type.LONG;
             }
         }
+        return null;
     }
 
     /**
@@ -91,17 +91,18 @@ public class CustomPlusFunctionExtension extends FunctionExecutor {
     }
 
     @Override
+    protected Object execute(Object[] objects, State state) {
+        return objects;
+    }
+
+    @Override
+    protected Object execute(Object o, State state) {
+        return o;
+    }
+
+    @Override
     public Attribute.Type getReturnType() {
         return returnType;
     }
 
-    @Override
-    public Map<String, Object> currentState() {
-        return new HashMap<>();
-    }
-
-    @Override
-    public void restoreState(Map<String, Object> map) {
-
-    }
 }

--- a/core/src/test/java/org/apache/flink/streaming/siddhi/operator/SiddhiSyntaxTest.java
+++ b/core/src/test/java/org/apache/flink/streaming/siddhi/operator/SiddhiSyntaxTest.java
@@ -21,11 +21,11 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.wso2.siddhi.core.SiddhiAppRuntime;
-import org.wso2.siddhi.core.SiddhiManager;
-import org.wso2.siddhi.core.event.Event;
-import org.wso2.siddhi.core.stream.input.InputHandler;
-import org.wso2.siddhi.core.stream.output.StreamCallback;
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.core.stream.output.StreamCallback;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/test/java/org/apache/flink/streaming/siddhi/schema/SiddhiExecutionPlanSchemaTest.java
+++ b/core/src/test/java/org/apache/flink/streaming/siddhi/schema/SiddhiExecutionPlanSchemaTest.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.streaming.siddhi.source.Event;
 import org.junit.Test;
-import org.wso2.siddhi.query.api.definition.Attribute;
-import org.wso2.siddhi.query.api.definition.StreamDefinition;
+import io.siddhi.query.api.definition.Attribute;
+import io.siddhi.query.api.definition.StreamDefinition;
 
 import static org.junit.Assert.*;
 

--- a/experimental/pom.xml
+++ b/experimental/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>flink-siddhi-parent_2.11</artifactId>
         <groupId>com.github.haoch</groupId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <groupId>com.github.haoch</groupId>
     <artifactId>flink-siddhi-parent_2.11</artifactId>
 
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.2.1-SNAPSHOT</version>
     <modules>
         <module>core</module>
         <module>experimental</module>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <packaging>pom</packaging>
 
     <properties>
-        <siddhi.version>4.2.40</siddhi.version>
+        <siddhi.version>5.1.2</siddhi.version>
         <flink.version>1.7.0</flink.version>
         <scala.binary.version>2.11</scala.binary.version>
     </properties>
@@ -42,7 +42,7 @@ under the License.
     <dependencies>
         <!-- core dependencies -->
         <dependency>
-            <groupId>org.wso2.siddhi</groupId>
+            <groupId>io.siddhi</groupId>
             <artifactId>siddhi-core</artifactId>
             <version>${siddhi.version}</version>
             <exclusions>
@@ -53,7 +53,7 @@ under the License.
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.wso2.siddhi</groupId>
+            <groupId>io.siddhi</groupId>
             <artifactId>siddhi-query-api</artifactId>
             <version>${siddhi.version}</version>
             <exclusions>
@@ -140,6 +140,16 @@ under the License.
             <id>wso2-maven2-repository</id>
             <name>WSO2 Maven2 Repository</name>
             <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+        <repository>
+            <id>wso2.releases</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
         </repository>
     </repositories>
     <pluginRepositories>


### PR DESCRIPTION
Fixes #45

I have added the support for the partition query. 

Now the query like this -
`partition with ( deviceID of TempStream) begin from every e1=TempStream[roomNo == 5]<3> -> e2=TempStream [ roomNo == 6] within 30 seconds select 'partition' as str, e1.roomNo as room insert into DeviceTempStream; end; ` 
will work fine. 

Reviews will be appreciated. 