### PR TITLE
fix handler npe

### DIFF
--- a/core/src/main/java/org/apache/flink/streaming/siddhi/router/AddRouteOperator.java
+++ b/core/src/main/java/org/apache/flink/streaming/siddhi/router/AddRouteOperator.java
@@ -61,8 +61,6 @@ public class AddRouteOperator extends AbstractStreamOperator<Tuple2<StreamRoute,
             } else if (value instanceof MetadataControlEvent) {
                 handleMetadataControlEvent((MetadataControlEvent)value);
             }
-
-            output.collect(element);
         } else {
             String inputStreamId = streamRoute.getInputStreamId();
             if (!inputStreamToExecutionPlans.containsKey(inputStreamId)) {


### PR DESCRIPTION
PR corrects the situation when data stream events are assigned to partitions by AddRouteOperator, but control events aren't. This happens because control events can't be distributed on broadcast rule through the DynamicPartitioner.
PR also fixes NPE in testDynamicalStreamSimplePatternMatch().
#64 